### PR TITLE
Dynamic settings, CSS, and misc. fixes

### DIFF
--- a/app/plmUtils.js
+++ b/app/plmUtils.js
@@ -5,12 +5,14 @@ define(['underscore'], function (_) {
 
     var SETTINGS = {
         BACK_TO_LEARNING_BUTTON_LABEL: 'back_to_learning_button_label',
-        SHOW_COPYRIGHT: 'show_copyright'
+        SHOW_COPYRIGHT: 'show_copyright',
+        SHOW_SECTIONS_HEADER: 'show_sections_header'
     };
 
     var DEFAULT_SETTINGS = {};
     DEFAULT_SETTINGS[SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL] = 'Done';
     DEFAULT_SETTINGS[SETTINGS.SHOW_COPYRIGHT] = true;
+    DEFAULT_SETTINGS[SETTINGS.SHOW_SECTIONS_HEADER] = true;
 
     function getSettings () {
         var dfd = Q.defer();
@@ -50,6 +52,10 @@ define(['underscore'], function (_) {
 
         getShowCopyrightSetting: function () {
             return getSetting(SETTINGS.SHOW_COPYRIGHT);
+        },
+
+        getShowSectionsHeaderSetting: function () {
+            return getSetting(SETTINGS.SHOW_SECTIONS_HEADER);
         },
 
 	showBackToLearning: window.self !== window.top,

--- a/app/plmUtils.js
+++ b/app/plmUtils.js
@@ -1,0 +1,33 @@
+define(function () {
+    'use strict';
+
+    var SETTINGS_PATH = 'https://s3.amazonaws.com/easy-generator-settings/plmSettings.json';
+    var DEFAULT_BACK_BUTTON_LABEL = 'Done';
+
+    return {
+        getBackButtonLabel: function () {
+            var dfd = Q.defer();
+            $.ajax({
+                url: SETTINGS_PATH,
+                dataType: 'json'
+            }).done(function (data) {
+                if (data) {
+                    dfd.resolve(data.back_to_learning_button_label || DEFAULT_BACK_BUTTON_LABEL);
+                } else {
+                    dfd.resolve(DEFAULT_BACK_BUTTON_LABEL);
+                }
+            }).fail(function () {
+                dfd.resolve(DEFAULT_BACK_BUTTON_LABEL);
+            });
+
+            return dfd.promise;
+        },
+
+	showBackToLearning: window.self !== window.top,
+
+        backToLearning: function () {
+            // Post a message for the PLM app.
+            window.parent.postMessage({name: 'backToLearning'}, '*');
+        }
+    };
+});

--- a/app/plmUtils.js
+++ b/app/plmUtils.js
@@ -1,26 +1,55 @@
-define(function () {
+define(['underscore'], function (_) {
     'use strict';
 
     var SETTINGS_PATH = 'https://s3.amazonaws.com/easy-generator-settings/plmSettings.json';
-    var DEFAULT_BACK_BUTTON_LABEL = 'Done';
+
+    var SETTINGS = {
+        BACK_TO_LEARNING_BUTTON_LABEL: 'back_to_learning_button_label',
+        SHOW_COPYRIGHT: 'show_copyright'
+    };
+
+    var DEFAULT_SETTINGS = {};
+    DEFAULT_SETTINGS[SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL] = 'Done';
+    DEFAULT_SETTINGS[SETTINGS.SHOW_COPYRIGHT] = true;
+
+    function getSettings () {
+        var dfd = Q.defer();
+        $.ajax({
+            url: SETTINGS_PATH,
+            dataType: 'json'
+        }).done(function (data) {
+            if (_.isObject(data)) {
+                dfd.resolve(_.extend({}, DEFAULT_SETTINGS, data));
+            } else {
+                dfd.resolve(DEFAULT_SETTINGS);
+            }
+        }).fail(function () {
+            dfd.resolve(DEFAULT_SETTINGS);
+        });
+
+        return dfd.promise;
+    }
+
+    function getSetting (setting) {
+        var dfd = Q.defer();
+        getSettings().then(function (settings) {
+            dfd.resolve(settings[setting]);
+        });
+
+        return dfd.promise;
+    }
 
     return {
-        getBackButtonLabel: function () {
-            var dfd = Q.defer();
-            $.ajax({
-                url: SETTINGS_PATH,
-                dataType: 'json'
-            }).done(function (data) {
-                if (data) {
-                    dfd.resolve(data.back_to_learning_button_label || DEFAULT_BACK_BUTTON_LABEL);
-                } else {
-                    dfd.resolve(DEFAULT_BACK_BUTTON_LABEL);
-                }
-            }).fail(function () {
-                dfd.resolve(DEFAULT_BACK_BUTTON_LABEL);
-            });
+        SETTINGS: SETTINGS,
 
-            return dfd.promise;
+        getSettings: getSettings,
+
+        getBackButtonLabel: function () {
+            return getSetting(SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL);
+        },
+
+        getShowCopyrightSetting: function () {
+            return getSetting(SETTINGS.SHOW_COPYRIGHT);
         },
 
 	showBackToLearning: window.self !== window.top,

--- a/app/plmUtils.js
+++ b/app/plmUtils.js
@@ -5,12 +5,14 @@ define(['underscore'], function (_) {
 
     var SETTINGS = {
         BACK_TO_LEARNING_BUTTON_LABEL: 'back_to_learning_button_label',
+        ERROR_PAGE_BUTTON_LABEL: 'error_page_button_label',
         SHOW_COPYRIGHT: 'show_copyright',
         SHOW_SECTIONS_HEADER: 'show_sections_header'
     };
 
     var DEFAULT_SETTINGS = {};
     DEFAULT_SETTINGS[SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL] = 'Done';
+    DEFAULT_SETTINGS[SETTINGS.ERROR_PAGE_BUTTON_LABEL] = 'Back';
     DEFAULT_SETTINGS[SETTINGS.SHOW_COPYRIGHT] = true;
     DEFAULT_SETTINGS[SETTINGS.SHOW_SECTIONS_HEADER] = true;
 
@@ -46,8 +48,12 @@ define(['underscore'], function (_) {
 
         getSettings: getSettings,
 
-        getBackButtonLabel: function () {
+        getBackToLearningButtonLabel: function () {
             return getSetting(SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL);
+        },
+
+        getErrorPageButtonLabel: function() {
+            return getSetting(SETTINGS.ERROR_PAGE_BUTTON_LABEL);
         },
 
         getShowCopyrightSetting: function () {

--- a/app/questionContent/questionContent.js
+++ b/app/questionContent/questionContent.js
@@ -15,7 +15,7 @@ define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation'
             this.isExpanded = ko.observable(true);
             this.isPreview = false;
             this.isSurvey = false;
-            this.copyright = templateSettings.copyright;
+            this.copyright = ko.observable();
 
             this.learningContents = [];
             this.correctFeedback = ko.observable(null);
@@ -78,6 +78,12 @@ define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation'
                 return;
             }
 
+            var self = this;
+            plmUtils.getSettings().then(function (settings) {
+                self.backToLearningButtonLabel(settings[plmUtils.SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL]);
+                self.copyright(settings[plmUtils.SETTINGS.SHOW_COPYRIGHT] && templateSettings.copyright);
+            });
+
             this.sectionId = sectionId;
             this.question = question;
             this.isPreview = _.isUndefined(isPreview) ? false : isPreview;
@@ -97,11 +103,6 @@ define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation'
             this.submitViewModel = this.activeQuestionViewModel.customSubmitViewModel || '';
 
             this.hideTryAgain = templateSettings.hideTryAgain;
-
-            var self = this;
-            plmUtils.getBackButtonLabel().then(function (label) {
-                self.backToLearningButtonLabel(label);
-            });
 
             if (isPreview) {
                 return this.question.loadContent().then(function(){

--- a/app/questionContent/questionContent.js
+++ b/app/questionContent/questionContent.js
@@ -1,5 +1,5 @@
-define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation', 'viewmodels/questions/questionsViewModelFactory', 'templateSettings'],
-    function (ko, router, constants, navigationModule, questionViewModelFactory, templateSettings) {
+define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation', 'viewmodels/questions/questionsViewModelFactory', 'templateSettings', 'plmUtils'],
+    function (ko, router, constants, navigationModule, questionViewModelFactory, templateSettings, plmUtils) {
         "use strict";
 
         function QuestionContent() {
@@ -38,13 +38,10 @@ define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation'
             });
 
             this.hideTryAgain = false;
-	    this.showBackToLearning = window.self !== window.top;
+	    this.showBackToLearning = plmUtils.showBackToLearning;
+            this.backToLearning = plmUtils.backToLearning;
+            this.backToLearningButtonLabel = ko.observable('');
         };
-
-        QuestionContent.prototype.backToLearning = function () {
-            // Post a message for the PLM app.
-            window.parent.postMessage({name: 'backToLearning'}, '*');
-        }
 
         QuestionContent.prototype.submit = function() {
             var self = this;
@@ -101,9 +98,12 @@ define(['knockout', 'plugins/router', 'constants', 'modules/questionsNavigation'
 
             this.hideTryAgain = templateSettings.hideTryAgain;
 
-            if(isPreview){
-                var self = this;
+            var self = this;
+            plmUtils.getBackButtonLabel().then(function (label) {
+                self.backToLearningButtonLabel(label);
+            });
 
+            if (isPreview) {
                 return this.question.loadContent().then(function(){
                     return self.activeQuestionViewModel.initialize(self.question, isPreview);
                 });

--- a/app/treeOfContent/treeOfContent.html
+++ b/app/treeOfContent/treeOfContent.html
@@ -8,7 +8,9 @@
                 <button class="tree-of-content-header-btn menu" data-bind="click: toggleIsExpanded.bind($data)">
                     <i class="tree-of-content-header-btn-icon menu material-icons">menu</i>
                 </button>
+                <!-- ko if: showSectionsHeader -->
                 <div class="tree-of-content-header-title" data-translate-text="[sections]"></div>
+                <!-- /ko -->
                 <button class="tree-of-content-header-btn close" data-bind="click: toggleIsExpanded.bind($data)">
                     <i class="tree-of-content-header-btn-icon close material-icons">close</i>
                 </button>

--- a/app/treeOfContent/treeOfContent.js
+++ b/app/treeOfContent/treeOfContent.js
@@ -1,5 +1,5 @@
-﻿define(['repositories/courseRepository', 'treeOfContent/treeNodes/SectionTreeNode', 'plugins/router', 'treeOfContent/utils/screenResolutionChecker'],
-function (courseRepository, SectionTreeNode, router, screenResolutionChecker) {
+﻿define(['repositories/courseRepository', 'treeOfContent/treeNodes/SectionTreeNode', 'plugins/router', 'treeOfContent/utils/screenResolutionChecker', 'plmUtils'],
+function (courseRepository, SectionTreeNode, router, screenResolutionChecker, plmUtils) {
     var viewModel = {
         children: [],
         hasChildren: false,
@@ -13,12 +13,18 @@ function (courseRepository, SectionTreeNode, router, screenResolutionChecker) {
         activate: activate,
         deactivate: deactivate,
         initializeRoute: initializeRoute,
-        activateQuestion: activateQuestion
+        activateQuestion: activateQuestion,
+        showSectionsHeader: ko.observable()
     };
 
     return viewModel;
 
     function activate() {
+        var self = this;
+        plmUtils.getShowSectionsHeaderSetting().then(function (showSectionsHeader) {
+            self.showSectionsHeader(showSectionsHeader);
+        });
+
         viewModel.children = _.chain(courseRepository.get().sections)
                 .map(function (section) {
                     var treeNode = new SectionTreeNode(section.id, section.title);

--- a/app/viewmodels/404.js
+++ b/app/viewmodels/404.js
@@ -2,15 +2,15 @@
 
     var activate = function () {
         var self = this;
-        plmUtils.getBackButtonLabel().finally(function (label) {
-            self.backToLearningButtonLabel(label);
+        plmUtils.getErrorPageButtonLabel().then(function (label) {
+            self.buttonLabel(label);
         });
     };
 
     var viewModel = {
         showBackToLearning: plmUtils.showBackToLearning,
         backToLearning: plmUtils.backToLearning,
-        backToLearningButtonLabel: ko.observable(''),
+        buttonLabel: ko.observable(''),
         activate: activate
     };
 

--- a/app/viewmodels/404.js
+++ b/app/viewmodels/404.js
@@ -1,13 +1,18 @@
-﻿define([], function () {
-    var viewModel = {
-        showBackToLearning: window.self !== window.top,
-        backToLearning: backToLearning
+﻿define(['knockout', 'plmUtils'], function (ko, plmUtils) {
+
+    var activate = function () {
+        var self = this;
+        plmUtils.getBackButtonLabel().finally(function (label) {
+            self.backToLearningButtonLabel(label);
+        });
     };
 
-    function backToLearning() {
-        // Post a message for the PLM app.
-        window.parent.postMessage({name: 'backToLearning'}, '*');
-    }
+    var viewModel = {
+        showBackToLearning: plmUtils.showBackToLearning,
+        backToLearning: plmUtils.backToLearning,
+        backToLearningButtonLabel: ko.observable(''),
+        activate: activate
+    };
 
     return viewModel;
 });

--- a/app/viewmodels/introduction.js
+++ b/app/viewmodels/introduction.js
@@ -1,5 +1,5 @@
-﻿define(['durandal/app', 'context', 'repositories/courseRepository', 'plugins/router', 'plugins/http', 'templateSettings'],
-    function (app, context, repository, router, http, templateSettings) {
+﻿define(['durandal/app', 'knockout', 'context', 'repositories/courseRepository', 'plugins/router', 'plugins/http', 'templateSettings', 'plmUtils'],
+    function (app, ko, context, repository, router, http, templateSettings, plmUtils) {
 
         var getFirstQuestionPath = function () {
 	    var course = repository.get();
@@ -11,7 +11,7 @@
 
         var courseTitle = null,
             content = null,
-            copyright = templateSettings.copyright,
+            copyright = ko.observable(),
 
             canActivate = function () {
                 if (context.course.hasIntroductionContent == false) {
@@ -22,6 +22,11 @@
 
             activate = function () {
                 this.courseTitle = context.course.title;
+
+                var self = this;
+                plmUtils.getShowCopyrightSetting().then(function (showCopyright) {
+                    self.copyright(showCopyright && templateSettings.copyright);
+                });
 
                 var that = this;
                 return Q.fcall(function () {

--- a/app/viewmodels/questions/informationContent.js
+++ b/app/viewmodels/questions/informationContent.js
@@ -1,16 +1,17 @@
-﻿define(['modules/questionsNavigation', 'plugins/router', 'templateSettings'], function (navigationModule, router, templateSettings) {
+﻿define(['knockout', 'modules/questionsNavigation', 'plugins/router', 'templateSettings', 'plmUtils'], function (ko, navigationModule, router, templateSettings, plmUtils) {
     "use strict";
 
     var viewModel = {
         title: null,
         learningContents: null,
         navigateNext: navigateNext,
-	showBackToLearning: window.self !== window.top,
-        backToLearning: backToLearning,
         copyright: templateSettings.copyright,
-
         activate: activate,
-        isNavigationLocked: router.isNavigationLocked
+        isNavigationLocked: router.isNavigationLocked,
+
+        showBackToLearning: plmUtils.showBackToLearning,
+        backToLearning: plmUtils.backToLearning,
+        backToLearningButtonLabel: ko.observable('')
     };
 
     return viewModel;
@@ -24,12 +25,12 @@
         router.navigate(nextUrl);
     }
 
-    function backToLearning() {
-        // Post a message for the PLM app.
-        window.parent.postMessage({name: 'backToLearning'}, '*');
-    }
-
     function activate(sectionId, question) {
+        var self = this;
+        plmUtils.getBackButtonLabel().then(function (label) {
+            self.backToLearningButtonLabel(label);
+        });
+
         return Q.fcall(function () {
             viewModel.navigationContext = navigationModule.getNavigationContext(sectionId, question.id);
             viewModel.id = question.id;

--- a/app/viewmodels/questions/informationContent.js
+++ b/app/viewmodels/questions/informationContent.js
@@ -5,7 +5,7 @@
         title: null,
         learningContents: null,
         navigateNext: navigateNext,
-        copyright: templateSettings.copyright,
+        copyright: ko.observable(),
         activate: activate,
         isNavigationLocked: router.isNavigationLocked,
 
@@ -27,8 +27,9 @@
 
     function activate(sectionId, question) {
         var self = this;
-        plmUtils.getBackButtonLabel().then(function (label) {
-            self.backToLearningButtonLabel(label);
+        plmUtils.getSettings().then(function (settings) {
+            self.backToLearningButtonLabel(settings[plmUtils.SETTINGS.BACK_TO_LEARNING_BUTTON_LABEL]);
+            self.copyright(settings[plmUtils.SETTINGS.SHOW_COPYRIGHT] && templateSettings.copyright);
         });
 
         return Q.fcall(function () {

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -6,7 +6,7 @@
             <div class="page-404-hint" data-translate-text="[page not found message]"></div>
 	    <!-- ko if: showBackToLearning -->
             <a href="#" data-bind="click: backToLearning" class="button primary medium">
-                <span>Back to Learning</span>
+                <span data-bind="text: backToLearningButtonLabel"></span>
             </a>
 	    <!-- /ko -->
         </div>

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -6,7 +6,7 @@
             <div class="page-404-hint" data-translate-text="[page not found message]"></div>
 	    <!-- ko if: showBackToLearning -->
             <a href="#" data-bind="click: backToLearning" class="button primary medium">
-                <span data-bind="text: backToLearningButtonLabel"></span>
+                <span data-bind="text: buttonLabel"></span>
             </a>
 	    <!-- /ko -->
         </div>

--- a/app/views/questions/feedback.html
+++ b/app/views/questions/feedback.html
@@ -12,10 +12,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary autofocus" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary autofocus" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary autofocus" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
         </div>
     </div>
@@ -30,10 +28,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary autofocus" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary autofocus" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary autofocus" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
         <!-- /ko -->
         <!-- ko ifnot: hideTryAgain -->
@@ -41,10 +37,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium default" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium default" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium default" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
         <!-- /ko -->
         </div>

--- a/app/views/questions/informationContent.html
+++ b/app/views/questions/informationContent.html
@@ -19,10 +19,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
         </div>
     </div>

--- a/app/views/questions/openQuestion/feedback.html
+++ b/app/views/questions/openQuestion/feedback.html
@@ -7,10 +7,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary autofocus" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary autofocus" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary autofocus" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
         </div>
     </div>
@@ -24,10 +22,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary autofocus" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary autofocus" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary autofocus" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
             <!-- /ko -->
             <!-- ko ifnot: hideTryAgain -->
@@ -35,10 +31,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium default" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium default" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium default" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
             <!-- /ko -->
         </div>

--- a/app/views/questions/scenarioQuestion/feedback.html
+++ b/app/views/questions/scenarioQuestion/feedback.html
@@ -7,10 +7,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary autofocus" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary autofocus" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary autofocus" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
         </div>
     </div>
@@ -24,10 +22,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium primary autofocus" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium primary autofocus" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium primary autofocus" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
             <!-- /ko -->
             <!-- ko ifnot: hideTryAgain -->
@@ -35,10 +31,8 @@
             <!-- ko if: navigationContext.nextQuestionUrl -->
             <button class="button medium default" data-bind="click: navigateNext, css: { disabled: isNavigationLocked }" data-translate-text="[next]" data-translate-title="[next]">Next</button>
             <!-- /ko -->
-            <!-- ko ifnot: navigationContext.nextQuestionUrl -->
-            <!-- ko if: showBackToLearning -->
-            <button class="button medium default" data-bind="click: backToLearning">Back to Learning</button>
-            <!-- /ko -->
+            <!-- ko if: !navigationContext.nextQuestionUrl && showBackToLearning -->
+            <button class="button medium default" data-bind="click: backToLearning, text: backToLearningButtonLabel"></button>
             <!-- /ko -->
             <!-- /ko -->
         </div>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     <!-- custom-styles -->
     <!-- endinject -->
 
+    <link href="https://s3.amazonaws.com/easy-generator-settings/plm-template-styles.css" rel="stylesheet" type="text/css" />
+
     <script type="text/javascript">
         if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
             var msViewportStyle = document.createElement("style");

--- a/manifest.json
+++ b/manifest.json
@@ -100,7 +100,7 @@
             "place": "google",
             "key": "Heading1",
             "size": 24,
-            "fontFamily": "Bentons Sans Medium",
+            "fontFamily": "Benton Sans Medium",
             "color": "#393939",
             "fontWeight": "400",
             "textDecoration": "none",


### PR DESCRIPTION
* Fetch PLM settings from S3, so that PLM team can easily update without Easy Generator code changes. Settings that currently exist:
  - backToLearning button label
  - 404 page button label
  - Whether to hide copyright (boolean)
  - Whether to hide 'Sections' heading (boolean)
* Include a PLM stylesheet hosted in S3, again so PLM can easily make changes to styles.
* Combine some knockout template logical statements.
* Fix typo in heading 1 font family name.